### PR TITLE
fix: close store in `read_as_dask` correctly

### DIFF
--- a/src/fancypackage/io/_dask.py
+++ b/src/fancypackage/io/_dask.py
@@ -1,9 +1,9 @@
 from collections.abc import Generator
 from itertools import chain
-from pathlib import Path
 
 import zarr
 from zarr import Group as ZarrGroup
+from zarr.storage import StoreLike
 
 from anndata import AnnData
 from anndata.experimental import read_elem_lazy
@@ -35,7 +35,7 @@ def _get_entries(group: ZarrGroup, level: str, entries: str | list[str] | None) 
 
 
 def read_as_dask(
-    store: Path | str,
+    store: StoreLike,
     layers: str | list[str] | None = None,
     obsm_keys: str | list[str] | None = None,
     varm_keys: str | list[str] | None = None,
@@ -88,6 +88,6 @@ def read_as_dask(
     for varm_key in varm_keys:
         adata.varm[varm_key] = read_elem_lazy(group[f"varm/{varm_key}"])
 
-    store.close()
+    group.store.close()
 
     return adata


### PR DESCRIPTION
## Changes

<!-- Please remove section if this PR does change an existing feature -->

- Update type hint for `store`

## Bug fixes

<!-- Please remove section if this PR does not fix any bugs -->

- Close store correctly

## Related issues

<!-- Please list related issues. If none exist, open one and reference it here. -->

Closes #86.
