### PR TITLE
ci: pre-commit hooks for R 4.6.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
       - id: check-merge-conflict
         args: [--assume-in-merge]
   - repo: https://github.com/lorenzwalthert/precommit
-    rev: v0.4.3.9021
+    rev: v0.4.3.9026
     hooks:
       - id: style-files
       - id: lintr


### PR DESCRIPTION
## Bug fixes

<!-- Please remove section if this PR does not fix any bugs -->

- bump pre-commit version for R hooks

## Related issues

<!-- Please list related issues. If none exist, open one and reference it here. -->

Closes #97.
