### PR TITLE
ci: update R version in lint CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,6 +25,11 @@ jobs:
         r-version: "4.6.0"
         use-public-rspm: true
 
+    - name: Install system dependencies for R packages
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y cmake libcurl4-openssl-dev libnode-dev pandoc
+
     - name: Cache pre-commit environments
       uses: actions/cache@v4
       with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
       id: setup-r
       uses: r-lib/actions/setup-r@v2
       with:
-        r-version: "4.5.3"
+        r-version: "4.6.0"
         use-public-rspm: true
 
     - name: Cache pre-commit environments


### PR DESCRIPTION
## Bug fixes

<!-- Please remove section if this PR does not fix any bugs -->

- Update R version to 4.6.0 in lint CI

## Related issues

<!-- Please list related issues. If none exist, open one and reference it here. -->

Closes #99.
