### PR TITLE
fix: remove redundant cookiecutter vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ uvx cruft create gh:WeilerP/sc_analysis_template
 
 You'll be prompted for:
 
-- `project_name` — human-readable project name
-- `package_name` — Python import name (derived from `project_name`, editable)
+- `project_name`: human-readable project name
+- `package_name`: Python import name (derived from `project_name`, editable)
 - `package_description`, `author_name`, `author_email`
-- `github_username` — your personal GitHub account (used for PAT-based auth, see below)
-- `github_namespace` — the account or organization the repo will live under (defaults to `github_username`; override for an org-owned repo, e.g. `dpeerlab`)
-- `docs_url`, `env_name`
+- `github_username`: your personal GitHub account (used for PAT-based auth, see below)
+- `github_namespace`: the account or organization the repo will live under (defaults to `github_username`; override for an org-owned repo, e.g. `dpeerlab`)
+- `docs_url`
 
 ## After generation
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ You'll be prompted for:
 - `package_name`: Python import name (derived from `project_name`, editable)
 - `package_description`, `author_name`, `author_email`
 - `github_username`: your personal GitHub account (used for PAT-based auth, see below)
-- `github_namespace`: the account or organization the repo will live under (defaults to `github_username`; override for an org-owned repo, e.g. `dpeerlab`)
-- `docs_url`
+- `github_namespace`: the account or organization the repo will live under (defaults to `github_username`)
 
 ## After generation
 

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -8,7 +8,6 @@
 	"github_username": "my-github-username",
 	"github_namespace": "{{ cookiecutter.github_username }}",
 	"github_repo_name": "{{ cookiecutter.project_name.lower().replace(' ', '-').replace('_', '-') }}",
-	"docs_url": "https://{{ cookiecutter.github_namespace }}.github.io/{{ cookiecutter.github_repo_name }}/",
 	"year": "2026",
 	"copyright_holder": "{{ cookiecutter.author_name }}",
 	"_copy_without_render": [

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -9,7 +9,6 @@
 	"github_namespace": "{{ cookiecutter.github_username }}",
 	"github_repo_name": "{{ cookiecutter.project_name.lower().replace(' ', '-').replace('_', '-') }}",
 	"docs_url": "https://{{ cookiecutter.github_namespace }}.github.io/{{ cookiecutter.github_repo_name }}/",
-	"env_name": "{{ cookiecutter.package_name }}-py314",
 	"year": "2026",
 	"copyright_holder": "{{ cookiecutter.author_name }}",
 	"_copy_without_render": [

--- a/{{ cookiecutter.project_name }}/.envrc
+++ b/{{ cookiecutter.project_name }}/.envrc
@@ -1,1 +1,1 @@
-export UV_PROJECT_ENVIRONMENT="$(pwd)/.{{ cookiecutter.env_name }}"
+export UV_PROJECT_ENVIRONMENT="$(pwd)/.venv"

--- a/{{ cookiecutter.project_name }}/README.md
+++ b/{{ cookiecutter.project_name }}/README.md
@@ -1,6 +1,6 @@
 # {{ cookiecutter.project_name }}
 
-{{ cookiecutter.package_description }} The corresponding Jupyter Book is rendered [here]({{ cookiecutter.docs_url }}).
+{{ cookiecutter.package_description }} The corresponding Jupyter Book is rendered [here](https://{{ cookiecutter.github_namespace }}.github.io/{{ cookiecutter.github_repo_name }}/).
 
 ## Project structure
 
@@ -126,7 +126,7 @@ Whenever you use a new single-cell tool, add it to `bio` in `pyproject.toml` so 
 
 ## Documentation
 
-The Jupyter Book is deployed [here]({{ cookiecutter.docs_url }}) on every push to `main`. To build and preview it locally:
+The Jupyter Book is deployed [here](https://{{ cookiecutter.github_namespace }}.github.io/{{ cookiecutter.github_repo_name }}/) on every push to `main`. To build and preview it locally:
 
 ```bash
 cd notebooks

--- a/{{ cookiecutter.project_name }}/notebooks/index.md
+++ b/{{ cookiecutter.project_name }}/notebooks/index.md
@@ -1,6 +1,6 @@
 # {{ cookiecutter.project_name }}
 
-{{ cookiecutter.package_description }} The corresponding Jupyter Book is rendered [here]({{ cookiecutter.docs_url }}).
+{{ cookiecutter.package_description }} The corresponding Jupyter Book is rendered [here](https://{{ cookiecutter.github_namespace }}.github.io/{{ cookiecutter.github_repo_name }}/).
 
 ## Project structure
 
@@ -126,7 +126,7 @@ Whenever you use a new single-cell tool, add it to `bio` in `pyproject.toml` so 
 
 ## Documentation
 
-The Jupyter Book is deployed [here]({{ cookiecutter.docs_url }}) on every push to `main`. To build and preview it locally:
+The Jupyter Book is deployed [here](https://{{ cookiecutter.github_namespace }}.github.io/{{ cookiecutter.github_repo_name }}/) on every push to `main`. To build and preview it locally:
 
 ```bash
 cd notebooks

--- a/{{ cookiecutter.project_name }}/pyproject.toml
+++ b/{{ cookiecutter.project_name }}/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "scanpy",
   "zarr>3",
 ]
-urls.Documentation = "{{ cookiecutter.docs_url }}"
+urls.Documentation = "https://{{ cookiecutter.github_namespace }}.github.io/{{ cookiecutter.github_repo_name }}/"
 urls.Home-page = "https://github.com/{{ cookiecutter.github_namespace }}/{{ cookiecutter.github_repo_name }}.git"
 urls.Source = "https://github.com/{{ cookiecutter.github_namespace }}/{{ cookiecutter.github_repo_name }}.git"
 


### PR DESCRIPTION
## Changes

* Remove `env_name` and `docs_url` variables from cookiecutter.

## Related issues

Closes #112. Closes #113.