### PR TITLE
refactor: update `plot_embedding`

### DIFF
--- a/{{ cookiecutter.project_name }}/src/{{ cookiecutter.package_name }}/plotting/_embedding.py
+++ b/{{ cookiecutter.project_name }}/src/{{ cookiecutter.package_name }}/plotting/_embedding.py
@@ -39,7 +39,15 @@ def plot_embedding(
     -------
     If `return_fig==True` the Matplotlib figure object.
     """
+    if (
+        ("color" in kwargs.keys())
+        and not isinstance(kwargs["color"], str)
+        and (len(kwargs["color"]) > 1)
+        and (figsize[0] == figsize[1])
+    ):
+        figsize = (len(kwargs["color"]) * figsize[0], figsize[1])
     sort_order = kwargs.pop("sort_order", False)
+
     fig = sc.pl.embedding(adata, sort_order=sort_order, return_fig=True, **kwargs)
 
     fig.set_size_inches(*figsize)


### PR DESCRIPTION
## Changes

<!-- Please remove section if this PR does change an existing feature -->

- Do not sort data point by default if colored by a continuous value.
- Update figure size if when more than one value is used for coloring. The updated figure size ensures that each individual figure is rectangular.

## Related issues

<!-- Please list related issues. If none exist, open one and reference it here. -->

Closes #119. Closes #120.
